### PR TITLE
Add functionality

### DIFF
--- a/classDef/PostPhasor.asv
+++ b/classDef/PostPhasor.asv
@@ -19,6 +19,8 @@ classdef PostPhasor < handle
         strain_histogram;
         strain_histogram_vector;
         strain_mask;
+        strain_mask_bulk;
+        strain_mask_shell;
         plotting;
         mask;           
         prtf;
@@ -140,7 +142,7 @@ classdef PostPhasor < handle
             
             try
                 postPhasor.strain = flip(postPhasor.strain,dimension);
-                postPhasor.strain_mask = flip(postPhasor.strain_mask,dimension);
+                postPhasor.strain_mask.whole = flip(postPhasor.strain_mask.whole,dimension);
                 fprintf('Strain is flipped along dimension %d\n',dimension);
             catch
                 error('Strain can not be flipped along selected dimension');
@@ -251,11 +253,11 @@ classdef PostPhasor < handle
             mask_shift(abs(strain_axis)) = 1;
 
             if abs(strain_axis) == 1
-                postPhasor.strain_mask = postPhasor.mask(1:end-1,:,:);
+                postPhasor.strain_mask.whole = postPhasor.mask(1:end-1,:,:);
             end
 
-            postPhasor.strain_mask = postPhasor.strain_mask+circshift(postPhasor.strain_mask,mask_shift);
-            postPhasor.strain_mask = postPhasor.strain_mask == 2;
+            postPhasor.strain_mask.whole = postPhasor.strain_mask.whole+circshift(postPhasor.strain_mask.whole,mask_shift);
+            postPhasor.strain_mask.whole = postPhasor.strain_mask.whole == 2;
             
             postPhasor.update_plotting_vectors;
         end
@@ -318,34 +320,58 @@ classdef PostPhasor < handle
             mask_shift(abs(strain_axis)) = 1;
 
             if abs(strain_axis) == 1
-                postPhasor.strain_mask = postPhasor.mask(1:end-1,:,:);
+                postPhasor.strain_mask.whole = postPhasor.mask(1:end-1,:,:);
             end
 
-            postPhasor.strain_mask = postPhasor.strain_mask+circshift(postPhasor.strain_mask,mask_shift);
-            postPhasor.strain_mask = postPhasor.strain_mask == 2;
+            postPhasor.strain_mask.whole = postPhasor.strain_mask.whole+circshift(postPhasor.strain_mask.whole,mask_shift);
+            postPhasor.strain_mask.whole = postPhasor.strain_mask.whole == 2;
             
             postPhasor.update_plotting_vectors;
         end
         
         function calculate_strain_histogram(postPhasor)
             figure;
-            hH = histogram(postPhasor.strain.*postPhasor.strain_mask,1000,'Normalization','probability'); %             
+            hH = histogram(postPhasor.strain.*postPhasor.strain_mask.whole,1000,'Normalization','probability'); %             
             set(gca,'FontSize',24);
             yline(max(hH.Values(:))/2); 
             yline(max(hH.Values(:))/4);             
             xlabel('Strain');
-            ylabel('Probability');
+            ylabel('Probability');         
             
+            max_val = max(hH.Values);
+            [val, pos] = find(hH.Values==max_val);
+            fprintf('%.2f%% of strain values are in the range: [%.2e : %.2e]%%\n', max(hH.Values)*100, hH.BinEdges(pos)*100, hH.BinEdges(pos+1)*100);
+                        
             postPhasor.strain_histogram = hH.Values;
-            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);  
-            
-            main_val = max(hH.Values);
-            [val, pos] = find(hH.Values==main_val);
-            fprintf('%.2f of strain values are in the range: [%.2:%.2]', max(hH.Values), hH.BinEdges(pos),)
+            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);                        
             
             figure; 
             plot(hH.BinEdges(1:end-1),log10(hH.Values));
             title('log-plot of probability');
+        end
+        
+        function segment_strain_mask(postPhasor)
+            sigma = 3;
+            threshold = 0.7;
+            if isempty(postPhasor.object)
+                error('No object defined! Create object first!')
+            else
+                try
+                    temp = imgaussfilt3(double(postPhasor.strain_mask),[sigma sigma sigma]);
+                catch
+                    error('Wrong dimensionality of the input data. Expect 3D');
+                end
+                                
+                postPhasor.strain_mask_bulk = temp>threshold; 
+                postPhasor.strain_mask_shell = postPhasor.strain_mask-postPhasor.strain_mask_bulk; 
+                          
+                % Estimate shell thickness
+                a(25:75) = 1;
+                b = imgaussfilt(a,3);
+                
+                fprintf('Mask is shrinked by sigma %.3f at threshold %.3f\n',sigma, threshold);
+                fprintf('Shell thickness: %.2f nm\n',)
+            end
         end
         
         function calculate_prtf(postPhasor)
@@ -470,9 +496,24 @@ classdef PostPhasor < handle
             vis3d(double(angle(postPhasor.object)), abs(postPhasor.object)>0.1);
         end
         
-        function iso3d_strain(postPhasor)
+        function iso3d_strain(postPhasor,domain)
+            if ~exist('domain')
+                domain = 'full';
+                disp('Displaying full strain isosurface');
+            end
             % Use an input parameter to show other complex valued matrix
-            input = postPhasor.strain.*postPhasor.strain_mask;      
+            switch domain
+                case 'full'
+                    strain_mask = postPhasor.strain_mask;      
+                    disp('Displaying full strain isosurface');
+                case 'bulk'
+                    strain_mask = postPhasor.strain_mask_bulk;  
+                    disp('Displaying bulk strain isosurface');
+                case 'shell'
+                    strain_mask = postPhasor.strain_mask_shell;  
+                    disp('Displaying shell strain isosurface');
+            end
+            input = postPhasor.strain.*strain_mask;
             
             handle = figure;     
             
@@ -489,14 +530,14 @@ classdef PostPhasor < handle
             isoVal = min(input(:));          
             hText = uicontrol('Parent',handle,'Style','text','String',sprintf('Strain value: %.4f',isoVal),'Units','Normalized',...
             'Position', [0.4 0.05 0.3 0.03]);
-            drawIsosurface(input,isoVal);            
+            drawIsosurface(input,isoVal,strain_mask);            
             
-            function drawIsosurface(input,isoVal)
+            function drawIsosurface(input,isoVal,strain_mask)
                 cla(ax);
                 axes(ax);
                 
                 % Shape isosurface  
-                isosurface(postPhasor.strain_mask);alpha(0.2)
+                isosurface(strain_mask);alpha(0.2)
                 xlabel('x, [nm]'); ylabel('y, [nm]'); zlabel('z, [nm]'); 
                 hold on;            
                 
@@ -517,7 +558,7 @@ classdef PostPhasor < handle
             
             function slideIsosurfaceReal(hObj,callbackdata)
                 isoVal = get(hObj,'Value');                 
-                drawIsosurface(input,isoVal);
+                drawIsosurface(input,isoVal,strain_mask);
             end  
         end
         
@@ -804,7 +845,7 @@ classdef PostPhasor < handle
             
             savemat2vtk(fullfile(save_path, 'object.vtk'),      postPhasor.object.*postPhasor.mask,     postPhasor.object_sampling);
             savemat2vtk(fullfile(save_path, 'displacement.vtk'),postPhasor.mask,                        postPhasor.object_sampling,     postPhasor.displacement.*postPhasor.mask);
-            savemat2vtk(fullfile(save_path, 'strain.vtk'),      postPhasor.strain_mask,                 postPhasor.object_sampling,     postPhasor.strain.*postPhasor.strain_mask);
+            savemat2vtk(fullfile(save_path, 'strain.vtk'),      postPhasor.strain_mask,           postPhasor.object_sampling,     postPhasor.strain.*postPhasor.strain_mask);
             
             % Save the whole instance
             save(fullfile(save_path, sprintf('postPhasor_%s.mat',postPhasor.dataTime)),'postPhasor');

--- a/classDef/PostPhasor.asv
+++ b/classDef/PostPhasor.asv
@@ -329,9 +329,28 @@ classdef PostPhasor < handle
             postPhasor.update_plotting_vectors;
         end
         
-        function calculate_strain_histogram(postPhasor)
+        function calculate_strain_histogram(postPhasor, domain)
+            if ~exist('domain')
+                domain = 'full';                
+            end
+            % Use an input parameter to show other complex valued matrix
+            switch domain
+                case 'full'
+                    strain_mask = postPhasor.strain_mask;      
+                    disp('Displaying full strain isosurface');
+                case 'bulk'
+                    strain_mask = postPhasor.strain_mask_bulk;  
+                    disp('Displaying bulk strain isosurface');
+                case 'shell'
+                    strain_mask = postPhasor.strain_mask_shell;  
+                    disp('Displaying shell strain isosurface');
+            end
+            
+            input = postPhasor.strain.*strain_mask;
+            % Test feature: exclude all 0 values of strain
+            input(input==0) = Nan;
             figure;
-            hH = histogram(postPhasor.strain.*postPhasor.strain_mask.whole,1000,'Normalization','probability'); %             
+            hH = histogram(input,1000,'Normalization','probability'); %             
             set(gca,'FontSize',24);
             yline(max(hH.Values(:))/2); 
             yline(max(hH.Values(:))/4);             
@@ -339,7 +358,7 @@ classdef PostPhasor < handle
             ylabel('Probability');         
             
             max_val = max(hH.Values);
-            [val, pos] = find(hH.Values==max_val);
+            [val, pos] = find(hH.Values == max_val);
             fprintf('%.2f%% of strain values are in the range: [%.2e : %.2e]%%\n', max(hH.Values)*100, hH.BinEdges(pos)*100, hH.BinEdges(pos+1)*100);
                         
             postPhasor.strain_histogram = hH.Values;
@@ -350,9 +369,14 @@ classdef PostPhasor < handle
             title('log-plot of probability');
         end
         
-        function segment_strain_mask(postPhasor)
-            sigma = 3;
-            threshold = 0.7;
+        function segment_strain_mask(postPhasor,sigma,threshold)
+            if nargin == 1
+                sigma = 6;
+                threshold = 0.75;
+            elseif nargin == 2
+                threshold = 0.75;
+            end
+            
             if isempty(postPhasor.object)
                 error('No object defined! Create object first!')
             else
@@ -366,11 +390,14 @@ classdef PostPhasor < handle
                 postPhasor.strain_mask_shell = postPhasor.strain_mask-postPhasor.strain_mask_bulk; 
                           
                 % Estimate shell thickness
+                a = zeros(100,1);
                 a(25:75) = 1;
-                b = imgaussfilt(a,3);
-                
+                b = imgaussfilt(a,sigma);
+                c = b>threshold;                
+                s = sum(a-c)/2;
+                th = s*postPhasor.object_sampling;
                 fprintf('Mask is shrinked by sigma %.3f at threshold %.3f\n',sigma, threshold);
-                fprintf('Shell thickness: %.2f nm\n',)
+                fprintf('Shell thickness: %.2f nm\n',th*1e9);
             end
         end
         
@@ -499,7 +526,6 @@ classdef PostPhasor < handle
         function iso3d_strain(postPhasor,domain)
             if ~exist('domain')
                 domain = 'full';
-                disp('Displaying full strain isosurface');
             end
             % Use an input parameter to show other complex valued matrix
             switch domain

--- a/classDef/PostPhasor.asv
+++ b/classDef/PostPhasor.asv
@@ -132,16 +132,18 @@ classdef PostPhasor < handle
         function flip(postPhasor,dimension)
             try
                 postPhasor.object = flip(postPhasor.object,dimension);
+                postPhasor.mask = flip(postPhasor.mask,dimension);
                 fprintf('Object is flipped along dimension %d\n',dimension);
             catch
                 error('Object can not be flipped along selected dimension');
             end
             
             try
-                postPhasor.object = flip(postPhasor.object,dimension);
-                fprintf('Object is flipped along dimension %d\n',dimension);
+                postPhasor.strain = flip(postPhasor.strain,dimension);
+                postPhasor.strain_mask = flip(postPhasor.strain_mask,dimension);
+                fprintf('Strain is flipped along dimension %d\n',dimension);
             catch
-                error('Object can not be flipped along selected dimension');
+                error('Strain can not be flipped along selected dimension');
             end
                 
         end
@@ -327,7 +329,7 @@ classdef PostPhasor < handle
         
         function calculate_strain_histogram(postPhasor)
             figure;
-            hH = histogram(postPhasor.strain(:),'Normalization','probability'); %             
+            hH = histogram(postPhasor.strain.*postPhasor.strain_mask,1000,'Normalization','probability'); %             
             set(gca,'FontSize',24);
             yline(max(hH.Values(:))/2); 
             yline(max(hH.Values(:))/4);             
@@ -335,30 +337,15 @@ classdef PostPhasor < handle
             ylabel('Probability');
             
             postPhasor.strain_histogram = hH.Values;
-            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);
+            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);  
             
-            lorentzian_fit(hH);
+            main_val = max(hH.Values);
+            [val, pos] = find(hH.Values==main_val);
+            fprintf('%.2f of strain values are in the range: [%.2:%.2]', max(hH.Values), hH.BinEdges(pos),)
             
-            function [fitresult, gof] = lorentzian_fit(hH)                 
-                [xData, yData] = prepareCurveData( [], hH.Values );
-
-                % Set up fittype and options.
-                ft = fittype( '1/(3.14*a*(1+((x-b)/a).^2))');
-                opts = fitoptions( 'Method', 'NonlinearLeastSquares' );
-                opts.Display = 'Off';
-                opts.StartPoint = [0.253634655350243 0.911927014033797];
-
-                % Fit model to data.
-                [fitresult, gof] = fit( xData, yData, ft)
-
-                % Plot fit with data.
-                figure( 'Name', 'untitled fit 1' );
-                h = plot( fitresult, xData, yData );
-                legend( h, 'Histogram', 'Lorentzian fit', 'Location', 'NorthEast', 'Interpreter', 'none' );
-                % Label axes
-                ylabel( 'Probability', 'Interpreter', 'none' );
-                grid on
-            end                
+            figure; 
+            plot(hH.BinEdges(1:end-1),log10(hH.Values));
+            title('log-plot of probability');
         end
         
         function calculate_prtf(postPhasor)
@@ -494,12 +481,12 @@ classdef PostPhasor < handle
             ax = axes('Parent',panel); 
             
             uicontrol('Parent',handle,'Style',...
-            'slider','Min',min(postPhasor.strain(:)),'Max',max(postPhasor.strain(:)),...
+            'slider','Min',min(input(:)),'Max',max(input(:)),...
             'Value',0,'Units','Normalized',...
             'Position', [0.1 0.05 0.3 0.03],...
             'Callback', @slideIsosurfaceReal); 
                     
-            isoVal = min(postPhasor.strain(:));          
+            isoVal = min(input(:));          
             hText = uicontrol('Parent',handle,'Style','text','String',sprintf('Strain value: %.4f',isoVal),'Units','Normalized',...
             'Position', [0.4 0.05 0.3 0.03]);
             drawIsosurface(input,isoVal);            
@@ -509,12 +496,12 @@ classdef PostPhasor < handle
                 axes(ax);
                 
                 % Shape isosurface  
-                isosurface(postPhasor.strain_mask);alpha(0.1)
+                isosurface(postPhasor.strain_mask);alpha(0.2)
                 xlabel('x, [nm]'); ylabel('y, [nm]'); zlabel('z, [nm]'); 
                 hold on;            
                 
                 % Strain isosurface
-                isosurface(input,isoVal);
+                isosurface(input,isoVal);hold on                
                 xlabel('x, [nm]'); ylabel('y, [nm]'); zlabel('z, [nm]'); 
                 rotate3d on;
                 grid on;

--- a/classDef/PostPhasor.m
+++ b/classDef/PostPhasor.m
@@ -496,12 +496,12 @@ classdef PostPhasor < handle
             ax = axes('Parent',panel); 
             
             uicontrol('Parent',handle,'Style',...
-            'slider','Min',min(postPhasor.strain(:)),'Max',max(postPhasor.strain(:)),...
+            'slider','Min',min(input(:)),'Max',max(input(:)),...
             'Value',0,'Units','Normalized',...
             'Position', [0.1 0.05 0.3 0.03],...
             'Callback', @slideIsosurfaceReal); 
                     
-            isoVal = min(postPhasor.strain(:));          
+            isoVal = min(input(:));          
             hText = uicontrol('Parent',handle,'Style','text','String',sprintf('Strain value: %.4f',isoVal),'Units','Normalized',...
             'Position', [0.4 0.05 0.3 0.03]);
             drawIsosurface(input,isoVal);            
@@ -516,9 +516,7 @@ classdef PostPhasor < handle
                 hold on;            
                 
                 % Strain isosurface
-                isosurface(input,isoVal);hold on
-                isosurface(input,isoVal+0.001);hold on
-                isosurface(input,isoVal-0.001);hold on
+                isosurface(input,isoVal);hold on                
                 xlabel('x, [nm]'); ylabel('y, [nm]'); zlabel('z, [nm]'); 
                 rotate3d on;
                 grid on;

--- a/classDef/PostPhasor.m
+++ b/classDef/PostPhasor.m
@@ -516,7 +516,9 @@ classdef PostPhasor < handle
                 hold on;            
                 
                 % Strain isosurface
-                isosurface(input,isoVal);
+                isosurface(input,isoVal);hold on
+                isosurface(input,isoVal+0.001);hold on
+                isosurface(input,isoVal-0.001);hold on
                 xlabel('x, [nm]'); ylabel('y, [nm]'); zlabel('z, [nm]'); 
                 rotate3d on;
                 grid on;

--- a/classDef/PostPhasor.m
+++ b/classDef/PostPhasor.m
@@ -329,7 +329,7 @@ classdef PostPhasor < handle
         
         function calculate_strain_histogram(postPhasor)
             figure;
-            hH = histogram(postPhasor.strain(:),'Normalization','probability'); %             
+            hH = histogram(postPhasor.strain.*postPhasor.strain_mask,1000); %             
             set(gca,'FontSize',24);
             yline(max(hH.Values(:))/2); 
             yline(max(hH.Values(:))/4);             
@@ -337,30 +337,11 @@ classdef PostPhasor < handle
             ylabel('Probability');
             
             postPhasor.strain_histogram = hH.Values;
-            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);
+            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);  
             
-            lorentzian_fit(hH);
-            
-            function [fitresult, gof] = lorentzian_fit(hH)                 
-                [xData, yData] = prepareCurveData( [], hH.Values );
-
-                % Set up fittype and options.
-                ft = fittype( '1/(3.14*a*(1+((x-b)/a).^2))');
-                opts = fitoptions( 'Method', 'NonlinearLeastSquares' );
-                opts.Display = 'Off';
-                opts.StartPoint = [0.253634655350243 0.911927014033797];
-
-                % Fit model to data.
-                [fitresult, gof] = fit( xData, yData, ft)
-
-                % Plot fit with data.
-                figure( 'Name', 'untitled fit 1' );
-                h = plot( fitresult, xData, yData );
-                legend( h, 'Histogram', 'Lorentzian fit', 'Location', 'NorthEast', 'Interpreter', 'none' );
-                % Label axes
-                ylabel( 'Probability', 'Interpreter', 'none' );
-                grid on
-            end                
+            figure; 
+            plot(hH.BinEdges(1:end-1),log10(hH.Values));
+            title('log-plot of probability');
         end
         
         function calculate_prtf(postPhasor)

--- a/classDef/PostPhasor.m
+++ b/classDef/PostPhasor.m
@@ -329,15 +329,19 @@ classdef PostPhasor < handle
         
         function calculate_strain_histogram(postPhasor)
             figure;
-            hH = histogram(postPhasor.strain.*postPhasor.strain_mask,1000); %             
+            hH = histogram(postPhasor.strain.*postPhasor.strain_mask,1000,'Normalization','probability'); %             
             set(gca,'FontSize',24);
             yline(max(hH.Values(:))/2); 
             yline(max(hH.Values(:))/4);             
             xlabel('Strain');
-            ylabel('Probability');
+            ylabel('Probability');         
             
+            max_val = max(hH.Values);
+            [val, pos] = find(hH.Values==max_val);
+            fprintf('%.2f%% of strain values are in the range: [%.2e : %.2e]%%\n', max(hH.Values)*100, hH.BinEdges(pos)*100, hH.BinEdges(pos+1)*100);
+                        
             postPhasor.strain_histogram = hH.Values;
-            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);  
+            postPhasor.strain_histogram_vector = hH.BinEdges(1:end-1);                        
             
             figure; 
             plot(hH.BinEdges(1:end-1),log10(hH.Values));


### PR DESCRIPTION
Added functionality:
- method <segment_strain_mask> for the separation of shell and bulk region of the sample. Should be extended towards any mask. The shell thickness is estimated from sigma value and threshold (similar to the shrinkwrap method).
-Now it is possible to plot histograms for shell and bulk parts of the object. Current domain selection: 'full', 'shell', 'bulk'
- method <iso3d_strain> shows the value of strain currently displayed. The isosurfaces of strains are inside of the current domain selection: 'full', 'shell', 'bulk'

Bug fixes:
- calculate_strain_histogram excludes 0 values of strain from the histogram. Instead, it provides the percentage of voxels with 0 strain. As a result, plots look clearer now

Minor improvements.
